### PR TITLE
Added support for mobile proxy and completing tasks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -153,6 +153,10 @@ dmypy.json
 # Cython debug symbols
 cython_debug/
 
+config/accounts.txt
+config/success_accounts.txt
+config/failed_accounts.txt
+
 # PyCharm
 #  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
 #  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@
 - **Auto registration**
 - **Auto bind referral**
 - **Auto bind twitter**
+- **Auto collect twitter tasks**
 - **Auto collect daily rewards every X time**
 
 
@@ -54,6 +55,7 @@
 
 ## ⚙️ Accounts format (config > accounts.txt)
 
+- twitter_auth_token|wallet_mnemonic|proxy|proxy_change_url
 - twitter_auth_token|wallet_mnemonic|proxy
 - twitter_auth_token|wallet_mnemonic
 

--- a/config/load_config.py
+++ b/config/load_config.py
@@ -26,6 +26,13 @@ def get_accounts() -> Account:
                     pk_or_mnemonic=values[1].strip(),
                     proxy=values[2].strip(),
                 )
+            elif len(values) == 4:
+                yield Account(
+                    auth_token=values[0].strip(),
+                    pk_or_mnemonic=values[1].strip(),
+                    proxy=values[2].strip(),
+                    proxy_change_url=values[3].strip(),
+                )
 
             else:
                 logger.error(

--- a/models/account.py
+++ b/models/account.py
@@ -6,6 +6,7 @@ class Account(BaseModel):
     auth_token: str
     pk_or_mnemonic: str
     proxy: str = None
+    proxy_change_url: str = None
 
 
     @field_validator("proxy", mode="before")

--- a/src/api.py
+++ b/src/api.py
@@ -252,7 +252,8 @@ class MintChainAPI(Wallet):
             logger.debug(f"Account: {self.account.auth_token} | Referral code bound")
 
     async def update_proxy(self) -> bool:
-        response = await self.session.get(self.account.proxy_change_url)
-        response.raise_for_status()
+        if self.account.proxy_change_url:
+            response = await self.session.get(self.account.proxy_change_url)
+            response.raise_for_status()
 
         return True

--- a/src/api.py
+++ b/src/api.py
@@ -230,3 +230,7 @@ class MintChainAPI(Wallet):
         if not data.user.inviteId:
             await self.bind_invite_code()
             logger.debug(f"Account: {self.account.auth_token} | Referral code bound")
+
+    async def update_proxy(self):
+        response = await self.session.get(self.account.proxy_change_url)
+        response.raise_for_status()

--- a/src/api.py
+++ b/src/api.py
@@ -58,12 +58,12 @@ class MintChainAPI(Wallet):
         return session
 
     async def send_request(
-        self,
-        request_type: Literal["POST", "GET"] = "POST",
-        method: str = None,
-        json_data: dict = None,
-        params: dict = None,
-        url: str = None,
+            self,
+            request_type: Literal["POST", "GET"] = "POST",
+            method: str = None,
+            json_data: dict = None,
+            params: dict = None,
+            url: str = None,
     ):
         def _verify_response(_response: dict) -> dict:
             if "code" in _response:
@@ -251,6 +251,8 @@ class MintChainAPI(Wallet):
             await self.bind_invite_code()
             logger.debug(f"Account: {self.account.auth_token} | Referral code bound")
 
-    async def update_proxy(self):
+    async def update_proxy(self) -> bool:
         response = await self.session.get(self.account.proxy_change_url)
         response.raise_for_status()
+
+        return True

--- a/src/bot.py
+++ b/src/bot.py
@@ -93,6 +93,7 @@ class Bot(MintChainAPI):
 
         try:
             operations = [
+                self.update_proxy,
                 self.process_login,
                 self.process_complete_tasks,
                 self.process_claim_daily_reward,
@@ -109,13 +110,6 @@ class Bot(MintChainAPI):
                 f"Account: {self.account.auth_token} | Unhandled error: {error}"
             )
         finally:
-            await self.safe_operation(
-                operation=self.update_proxy,
-                success_message="Proxy updated",
-                error_message="Failed to update proxy",
-                retries=3,
-            )
-
             logger.success(
                 f"Account: {self.account.auth_token} | Finished | Waiting for next iteration.."
             )

--- a/src/bot.py
+++ b/src/bot.py
@@ -100,6 +100,13 @@ class Bot(MintChainAPI):
                 f"Account: {self.account.auth_token} | Unhandled error: {error}"
             )
         finally:
+            await self.safe_operation(
+                operation=self.update_proxy,
+                success_message="Proxy updated",
+                error_message="Failed to update proxy",
+                retries=3,
+            )
+
             logger.success(
                 f"Account: {self.account.auth_token} | Finished | Waiting for next iteration.."
             )

--- a/src/bot.py
+++ b/src/bot.py
@@ -76,6 +76,14 @@ class Bot(MintChainAPI):
                 f"Account: {self.account.auth_token} | Failed to get user info: {error} | Daily actions done.."
             )
 
+    async def process_complete_tasks(self) -> bool:
+        return await self.safe_operation(
+            operation=self.complete_all_tasks,
+            success_message="All tasks have been completed",
+            error_message="Failed to complete all tasks",
+            retries=3,
+        )
+
     async def start(self):
         random_delay = random.randint(1, 30)
         logger.info(
@@ -86,6 +94,7 @@ class Bot(MintChainAPI):
         try:
             operations = [
                 self.process_login,
+                self.process_complete_tasks,
                 self.process_claim_daily_reward,
                 self.process_inject,
                 self.process_show_user_info,


### PR DESCRIPTION
# Support for mobile proxy
If you add accounts in this format:
- twitter_auth_token|wallet_mnemonic|proxy|proxy_change_url

Then bot will send get request to proxy_change_url to update ip before processing account

# Completing tasks
Only two twitter tasks can be completed without any actions, bot will claim rewards for them automatically